### PR TITLE
새 카드 추가 화면 UI 구현

### DIFF
--- a/iOS/TodoApp/TodoApp.xcodeproj/project.pbxproj
+++ b/iOS/TodoApp/TodoApp.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		443D100A243B9974003F2635 /* AddCardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443D1009243B9974003F2635 /* AddCardButton.swift */; };
 		443D1010243C4B99003F2635 /* TodoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443D100F243C4B99003F2635 /* TodoViewController.swift */; };
 		443D1012243C4D87003F2635 /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443D1011243C4D87003F2635 /* TodoCell.swift */; };
+		443D1014243CC60C003F2635 /* ContentTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443D1013243CC60C003F2635 /* ContentTextView.swift */; };
+		443D1016243CC77A003F2635 /* EditingCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443D1015243CC77A003F2635 /* EditingCardViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +34,8 @@
 		443D1009243B9974003F2635 /* AddCardButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCardButton.swift; sourceTree = "<group>"; };
 		443D100F243C4B99003F2635 /* TodoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoViewController.swift; sourceTree = "<group>"; };
 		443D1011243C4D87003F2635 /* TodoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
+		443D1013243CC60C003F2635 /* ContentTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTextView.swift; sourceTree = "<group>"; };
+		443D1015243CC77A003F2635 /* EditingCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingCardViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +73,7 @@
 				443D0FEA243B3F3D003F2635 /* SceneDelegate.swift */,
 				443D0FEC243B3F3D003F2635 /* ViewController.swift */,
 				443D100F243C4B99003F2635 /* TodoViewController.swift */,
+				443D1015243CC77A003F2635 /* EditingCardViewController.swift */,
 				443D0FEE243B3F3D003F2635 /* Main.storyboard */,
 				443D0FF1243B3F3E003F2635 /* Assets.xcassets */,
 				443D0FF3243B3F3E003F2635 /* LaunchScreen.storyboard */,
@@ -83,6 +88,7 @@
 				443D1007243B968F003F2635 /* CardCountLabel.swift */,
 				443D1009243B9974003F2635 /* AddCardButton.swift */,
 				443D1011243C4D87003F2635 /* TodoCell.swift */,
+				443D1013243CC60C003F2635 /* ContentTextView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -161,10 +167,12 @@
 				443D0FED243B3F3D003F2635 /* ViewController.swift in Sources */,
 				443D0FE9243B3F3D003F2635 /* AppDelegate.swift in Sources */,
 				443D1012243C4D87003F2635 /* TodoCell.swift in Sources */,
+				443D1014243CC60C003F2635 /* ContentTextView.swift in Sources */,
 				443D1008243B968F003F2635 /* CardCountLabel.swift in Sources */,
 				443D0FEB243B3F3D003F2635 /* SceneDelegate.swift in Sources */,
 				443D1010243C4B99003F2635 /* TodoViewController.swift in Sources */,
 				443D100A243B9974003F2635 /* AddCardButton.swift in Sources */,
+				443D1016243CC77A003F2635 /* EditingCardViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
+++ b/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
@@ -343,17 +343,26 @@
                                 <state key="normal" title="Cancel"/>
                             </button>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kxi-0A-pbg">
-                                <rect key="frame" x="20" y="95" width="62" height="36"/>
+                                <rect key="frame" x="20" y="95" width="617" height="36"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mKD-Dk-ugj">
+                                <rect key="frame" x="647" y="95" width="35" height="34"/>
+                                <state key="normal" image="arrow.up.circle.fill" catalog="system">
+                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="30" scale="default"/>
+                                </state>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="kxi-0A-pbg" firstAttribute="leading" secondItem="LI2-sH-0pQ" secondAttribute="leading" id="4Q0-Tu-rI7"/>
+                            <constraint firstItem="qXT-ur-60j" firstAttribute="trailing" secondItem="mKD-Dk-ugj" secondAttribute="trailing" constant="30" id="Bs7-jM-Dra"/>
                             <constraint firstItem="LI2-sH-0pQ" firstAttribute="top" secondItem="qXT-ur-60j" secondAttribute="top" constant="25" id="Ijt-sd-1l3"/>
+                            <constraint firstItem="mKD-Dk-ugj" firstAttribute="top" secondItem="kxi-0A-pbg" secondAttribute="top" id="dK3-8M-3gw"/>
                             <constraint firstItem="kxi-0A-pbg" firstAttribute="top" secondItem="LI2-sH-0pQ" secondAttribute="bottom" constant="40" id="fsJ-ar-Xgm"/>
                             <constraint firstItem="LI2-sH-0pQ" firstAttribute="leading" secondItem="qXT-ur-60j" secondAttribute="leading" constant="20" id="u3Z-Qu-eOA"/>
+                            <constraint firstItem="mKD-Dk-ugj" firstAttribute="leading" secondItem="kxi-0A-pbg" secondAttribute="trailing" constant="10" id="xWe-uQ-odH"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="qXT-ur-60j"/>
                     </view>
@@ -364,6 +373,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="arrow.up.circle.fill" catalog="system" width="64" height="60"/>
         <image name="text.justify" catalog="system" width="64" height="50"/>
     </resources>
 </document>

--- a/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
+++ b/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
@@ -44,6 +44,9 @@
                                     <navigationItem id="YGX-rS-i6C">
                                         <barButtonItem key="rightBarButtonItem" title="Menu" id="wzz-d5-cpH">
                                             <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <connections>
+                                                <segue destination="GyP-ax-8bf" kind="presentation" id="4ln-qO-22f"/>
+                                            </connections>
                                         </barButtonItem>
                                     </navigationItem>
                                 </items>
@@ -332,9 +335,19 @@
             <objects>
                 <viewController id="GyP-ax-8bf" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="3NH-Nx-1FC">
-                        <rect key="frame" x="0.0" y="0.0" width="1194" height="834"/>
+                        <rect key="frame" x="0.0" y="0.0" width="712" height="794"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LI2-sH-0pQ">
+                                <rect key="frame" x="20" y="25" width="48" height="30"/>
+                                <state key="normal" title="Cancel"/>
+                            </button>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="LI2-sH-0pQ" firstAttribute="top" secondItem="qXT-ur-60j" secondAttribute="top" constant="25" id="Ijt-sd-1l3"/>
+                            <constraint firstItem="LI2-sH-0pQ" firstAttribute="leading" secondItem="qXT-ur-60j" secondAttribute="leading" constant="20" id="u3Z-Qu-eOA"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="qXT-ur-60j"/>
                     </view>
                 </viewController>

--- a/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
+++ b/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
@@ -71,7 +71,7 @@
             <objects>
                 <viewController id="BlN-4l-ztd" customClass="TodoViewController" customModule="TodoApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="a5W-HH-5xp">
-                        <rect key="frame" x="0.0" y="0.0" width="384.5" height="814"/>
+                        <rect key="frame" x="0.0" y="0.0" width="385" height="814"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Mq-JW-AzN">
@@ -266,7 +266,7 @@
             <objects>
                 <viewController id="WeY-TX-z0Y" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="NoR-Is-uby">
-                        <rect key="frame" x="0.0" y="0.0" width="384.5" height="814"/>
+                        <rect key="frame" x="0.0" y="0.0" width="385" height="814"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2kP-4k-XdY">
@@ -341,6 +341,9 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LI2-sH-0pQ">
                                 <rect key="frame" x="20" y="25" width="48" height="30"/>
                                 <state key="normal" title="Cancel"/>
+                                <connections>
+                                    <action selector="cancelButtonTabbed:" destination="GyP-ax-8bf" eventType="touchUpInside" id="Ejx-jd-P8I"/>
+                                </connections>
                             </button>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kxi-0A-pbg">
                                 <rect key="frame" x="20" y="95" width="289.5" height="36"/>

--- a/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
+++ b/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
@@ -342,10 +342,17 @@
                                 <rect key="frame" x="20" y="25" width="48" height="30"/>
                                 <state key="normal" title="Cancel"/>
                             </button>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kxi-0A-pbg">
+                                <rect key="frame" x="20" y="95" width="62" height="36"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
+                            <constraint firstItem="kxi-0A-pbg" firstAttribute="leading" secondItem="LI2-sH-0pQ" secondAttribute="leading" id="4Q0-Tu-rI7"/>
                             <constraint firstItem="LI2-sH-0pQ" firstAttribute="top" secondItem="qXT-ur-60j" secondAttribute="top" constant="25" id="Ijt-sd-1l3"/>
+                            <constraint firstItem="kxi-0A-pbg" firstAttribute="top" secondItem="LI2-sH-0pQ" secondAttribute="bottom" constant="40" id="fsJ-ar-Xgm"/>
                             <constraint firstItem="LI2-sH-0pQ" firstAttribute="leading" secondItem="qXT-ur-60j" secondAttribute="leading" constant="20" id="u3Z-Qu-eOA"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="qXT-ur-60j"/>

--- a/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
+++ b/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
@@ -330,12 +330,12 @@
             </objects>
             <point key="canvasLocation" x="1049" y="829"/>
         </scene>
-        <!--View Controller-->
+        <!--Editing Card View Controller-->
         <scene sceneID="5sk-ZQ-Myt">
             <objects>
-                <viewController id="GyP-ax-8bf" sceneMemberID="viewController">
+                <viewController id="GyP-ax-8bf" customClass="EditingCardViewController" customModule="TodoApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="3NH-Nx-1FC">
-                        <rect key="frame" x="0.0" y="0.0" width="384.5" height="794"/>
+                        <rect key="frame" x="0.0" y="0.0" width="385" height="794"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LI2-sH-0pQ">
@@ -353,7 +353,7 @@
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="30" scale="default"/>
                                 </state>
                             </button>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="YWP-mF-4OG">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="YWP-mF-4OG" customClass="ContentTextView" customModule="TodoApp" customModuleProvider="target">
                                 <rect key="frame" x="20" y="161" width="334.5" height="392"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
@@ -386,6 +386,9 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="qXT-ur-60j"/>
                     </view>
+                    <connections>
+                        <outlet property="contentTextView" destination="YWP-mF-4OG" id="tRJ-dX-qid"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Bcc-4M-MI6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
+++ b/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
@@ -327,6 +327,21 @@
             </objects>
             <point key="canvasLocation" x="1049" y="829"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="5sk-ZQ-Myt">
+            <objects>
+                <viewController id="GyP-ax-8bf" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="3NH-Nx-1FC">
+                        <rect key="frame" x="0.0" y="0.0" width="1194" height="834"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="qXT-ur-60j"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Bcc-4M-MI6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1537" y="350"/>
+        </scene>
     </scenes>
     <resources>
         <image name="text.justify" catalog="system" width="64" height="50"/>

--- a/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
+++ b/iOS/TodoApp/TodoApp/Base.lproj/Main.storyboard
@@ -44,9 +44,6 @@
                                     <navigationItem id="YGX-rS-i6C">
                                         <barButtonItem key="rightBarButtonItem" title="Menu" id="wzz-d5-cpH">
                                             <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            <connections>
-                                                <segue destination="GyP-ax-8bf" kind="presentation" id="4ln-qO-22f"/>
-                                            </connections>
                                         </barButtonItem>
                                     </navigationItem>
                                 </items>
@@ -100,6 +97,9 @@
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" button="YES" image="YES"/>
                                         </accessibility>
+                                        <connections>
+                                            <segue destination="GyP-ax-8bf" kind="presentation" id="fxO-yL-gNA"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -335,7 +335,7 @@
             <objects>
                 <viewController id="GyP-ax-8bf" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="3NH-Nx-1FC">
-                        <rect key="frame" x="0.0" y="0.0" width="712" height="794"/>
+                        <rect key="frame" x="0.0" y="0.0" width="384.5" height="794"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LI2-sH-0pQ">
@@ -343,24 +343,44 @@
                                 <state key="normal" title="Cancel"/>
                             </button>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kxi-0A-pbg">
-                                <rect key="frame" x="20" y="95" width="617" height="36"/>
+                                <rect key="frame" x="20" y="95" width="289.5" height="36"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="500" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mKD-Dk-ugj">
-                                <rect key="frame" x="647" y="95" width="35" height="34"/>
+                                <rect key="frame" x="319.5" y="95" width="35" height="34"/>
                                 <state key="normal" image="arrow.up.circle.fill" catalog="system">
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="30" scale="default"/>
                                 </state>
                             </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="YWP-mF-4OG">
+                                <rect key="frame" x="20" y="161" width="334.5" height="392"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author by iOS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yNh-v6-KSH">
+                                <rect key="frame" x="20" y="573" width="334.5" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
+                            <constraint firstItem="qXT-ur-60j" firstAttribute="trailing" secondItem="YWP-mF-4OG" secondAttribute="trailing" constant="30" id="3Lb-Yz-3qp"/>
                             <constraint firstItem="kxi-0A-pbg" firstAttribute="leading" secondItem="LI2-sH-0pQ" secondAttribute="leading" id="4Q0-Tu-rI7"/>
                             <constraint firstItem="qXT-ur-60j" firstAttribute="trailing" secondItem="mKD-Dk-ugj" secondAttribute="trailing" constant="30" id="Bs7-jM-Dra"/>
+                            <constraint firstItem="qXT-ur-60j" firstAttribute="trailing" secondItem="yNh-v6-KSH" secondAttribute="trailing" constant="30" id="EQY-tF-rGZ"/>
+                            <constraint firstItem="yNh-v6-KSH" firstAttribute="leading" secondItem="qXT-ur-60j" secondAttribute="leading" constant="20" id="FZS-nb-sRI"/>
+                            <constraint firstItem="YWP-mF-4OG" firstAttribute="leading" secondItem="qXT-ur-60j" secondAttribute="leading" constant="20" id="INS-gd-Rhc"/>
                             <constraint firstItem="LI2-sH-0pQ" firstAttribute="top" secondItem="qXT-ur-60j" secondAttribute="top" constant="25" id="Ijt-sd-1l3"/>
+                            <constraint firstItem="qXT-ur-60j" firstAttribute="bottom" secondItem="yNh-v6-KSH" secondAttribute="bottom" constant="200" id="XU9-4r-bCQ"/>
                             <constraint firstItem="mKD-Dk-ugj" firstAttribute="top" secondItem="kxi-0A-pbg" secondAttribute="top" id="dK3-8M-3gw"/>
                             <constraint firstItem="kxi-0A-pbg" firstAttribute="top" secondItem="LI2-sH-0pQ" secondAttribute="bottom" constant="40" id="fsJ-ar-Xgm"/>
+                            <constraint firstItem="YWP-mF-4OG" firstAttribute="top" secondItem="kxi-0A-pbg" secondAttribute="bottom" constant="30" id="gH3-YE-MMU"/>
+                            <constraint firstItem="yNh-v6-KSH" firstAttribute="top" secondItem="YWP-mF-4OG" secondAttribute="bottom" constant="20" id="o7J-jd-6TG"/>
                             <constraint firstItem="LI2-sH-0pQ" firstAttribute="leading" secondItem="qXT-ur-60j" secondAttribute="leading" constant="20" id="u3Z-Qu-eOA"/>
                             <constraint firstItem="mKD-Dk-ugj" firstAttribute="leading" secondItem="kxi-0A-pbg" secondAttribute="trailing" constant="10" id="xWe-uQ-odH"/>
                         </constraints>

--- a/iOS/TodoApp/TodoApp/EditingCardViewController.swift
+++ b/iOS/TodoApp/TodoApp/EditingCardViewController.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 class EditingCardViewController: UIViewController, UITextViewDelegate {
+    private let contentCharactorCountLimit = 500
+    
     @IBOutlet weak var contentTextView: ContentTextView!
     
     override func viewDidLoad() {
@@ -26,7 +28,7 @@ class EditingCardViewController: UIViewController, UITextViewDelegate {
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         guard let textView = textView as? ContentTextView,
-            textView.text.count + (text.count - range.length) <= 500 else { return false }
+            textView.text.count + (text.count - range.length) <= contentCharactorCountLimit else { return false }
         let updatedText = (textView.text as NSString).replacingCharacters(in: range, with: text)
         if updatedText.isEmpty {
             textView.setPlaceholder()

--- a/iOS/TodoApp/TodoApp/EditingCardViewController.swift
+++ b/iOS/TodoApp/TodoApp/EditingCardViewController.swift
@@ -1,0 +1,42 @@
+//
+//  EditingCardViewController.swift
+//  TodoApp
+//
+//  Created by TTOzzi on 2020/04/07.
+//  Copyright © 2020 TTOzzi. All rights reserved.
+//
+
+import UIKit
+
+class EditingCardViewController: UIViewController, UITextViewDelegate {
+    @IBOutlet weak var contentTextView: ContentTextView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        contentTextView.delegate = self
+    }
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == .placeholderText {
+            DispatchQueue.main.async {
+                textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
+            }
+        }
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        guard let textView = textView as? ContentTextView,
+            textView.text.count + (text.count - range.length) <= 500 else { return false }
+        let updatedText = (textView.text as NSString).replacingCharacters(in: range, with: text)
+        if updatedText.isEmpty {
+            textView.setPlaceholder()
+            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.beginningOfDocument)
+        } else if textView.textColor == .placeholderText && !text.isEmpty {
+            textView.textColor = UIColor.black
+            textView.text = text
+        } else {
+            return true
+        }
+        return false
+    }
+}

--- a/iOS/TodoApp/TodoApp/EditingCardViewController.swift
+++ b/iOS/TodoApp/TodoApp/EditingCardViewController.swift
@@ -39,4 +39,8 @@ class EditingCardViewController: UIViewController, UITextViewDelegate {
         }
         return false
     }
+    
+    @IBAction func cancelButtonTabbed(_ sender: UIButton) {
+        dismiss(animated: true, completion: nil)
+    }
 }

--- a/iOS/TodoApp/TodoApp/View/ContentTextView.swift
+++ b/iOS/TodoApp/TodoApp/View/ContentTextView.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 class ContentTextView: UITextView {
+    private let placeholder = "Content"
+    
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
         setProperties()
@@ -26,7 +28,7 @@ class ContentTextView: UITextView {
     }
     
     func setPlaceholder() {
-        self.text = "Content"
+        self.text = placeholder
         self.textColor = .placeholderText
     }
 }

--- a/iOS/TodoApp/TodoApp/View/ContentTextView.swift
+++ b/iOS/TodoApp/TodoApp/View/ContentTextView.swift
@@ -1,0 +1,32 @@
+//
+//  ContentTextView.swift
+//  TodoApp
+//
+//  Created by TTOzzi on 2020/04/07.
+//  Copyright © 2020 TTOzzi. All rights reserved.
+//
+
+import UIKit
+
+class ContentTextView: UITextView {
+    override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+        setProperties()
+        setPlaceholder()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setProperties()
+        setPlaceholder()
+    }
+    
+    private func setProperties() {
+        self.autocorrectionType = .no
+    }
+    
+    func setPlaceholder() {
+        self.text = "Content"
+        self.textColor = .placeholderText
+    }
+}

--- a/iOS/TodoApp/TodoApp/View/TodoCell.swift
+++ b/iOS/TodoApp/TodoApp/View/TodoCell.swift
@@ -13,15 +13,9 @@ class TodoCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setProperties()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        setProperties()
-    }
-    
-    func setProperties() {
-        
     }
 }


### PR DESCRIPTION
새 카드 추가 화면의 기본적인 UI 를 구현하였습니다.
TextView 의 placeholder 를 최대한 TextField 의 placeholder 와 흡사하게 동작하게끔 구현하려고 노력하였습니다.


### 스토리보드로 화면을 만드는데 Container ViewController 의 button 과 새로운 화면을 segue 로 이어주니 시뮬레이터에선 큰 화면이 modal 로 나오는데 스토리보드에서는 ContainerView 의 크기만큼만 나오는 문제가 있었습니다. 
<img width="1680" alt="스크린샷 2020-04-07 오후 7 54 03" src="https://user-images.githubusercontent.com/50410213/78692701-381eed80-7935-11ea-80dd-6da2ea6d3c56.png">

### 어차피 오토레이아웃으로 잡아주면 똑같이 나오긴 하지만 구현할 때 불편해서 임의로 큰 전체화면의 버튼과 segue 로 이어줘서 큰 화면으로 구현하였습니다.
<img width="1680" alt="스크린샷 2020-04-07 오후 7 54 38" src="https://user-images.githubusercontent.com/50410213/78692709-3b19de00-7935-11ea-8a15-5921ac80e0ca.png">

### 이런 경우에는 어떻게 해야 할까요..?