### PR TITLE
드래그앤 드랍 기능 구현

### DIFF
--- a/iOS/TodoApp/TodoApp/Todo/Model/ColumnManager.swift
+++ b/iOS/TodoApp/TodoApp/Todo/Model/ColumnManager.swift
@@ -32,7 +32,7 @@ class ColumnManager {
     }
     
     func insertCard(at indexPath: IndexPath = IndexPath(row: 0, section: 0), with card: Card) {
-        task.insert(card, at: 0)
+        task.insert(card, at: indexPath.row)
         NotificationCenter.default.post(name: ColumnManager.cardInserted, object: self, userInfo: ["indexPath": indexPath])
     }
     

--- a/iOS/TodoApp/TodoApp/Todo/TodoViewController.swift
+++ b/iOS/TodoApp/TodoApp/Todo/TodoViewController.swift
@@ -235,11 +235,11 @@ extension TodoViewController: UITableViewDragDelegate ,UITableViewDropDelegate {
             let row = tableView.numberOfRows(inSection: section)
             destinationIndexPath = IndexPath(row: row, section: section)
         }
-        guard var card = coordinator.items.first?.dragItem.localObject as? Card else { return }
+        guard let card = coordinator.items.first?.dragItem.localObject as? Card else { return }
         if card.categoryId != manager.id || draggedCellIndex != destinationIndexPath {
-            card.categoryId = manager.id
             NotificationCenter.default.post(name: NSNotification.Name.init("drop"), object: nil)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.00001) {
+            TodoNetworkManager.moveCardRequest(card: card, category: manager.id, index: destinationIndexPath.row) { card in
+                guard let card = card else { return }
                 self.manager.insertCard(at: destinationIndexPath, with: card)
             }
         }


### PR DESCRIPTION
#### API 서버와 통신하는 드래그앤 드랍 기능을 구현하였습니다.

* 카드가 드랍되는 시점에 서버에 카드이동 요청을 보내 돌아온 응답에 따라 동작을 나눠주었습니다.
  * 요청 성공 시 드래그한 카드의 출처로 노티를 보내 해당 카드를 지워주고 응답으로 받은 카드를 해당 indexPath 에 넣어줍니다.
  * 요청 실패 시 alert 를 띄워 사용자에게 실패를 알려줍니다.


* 드래그한 카드를 지워주기 위해선 드랍 된 뷰 컨트롤러에서 드래그한 카드의 출처 뷰컨을 알아야 하는데 이를 위해 단발성 노티를 만들어 주었습니다. 간단히 동작을 설명하자면
1. 카드를 드래그한 시점에 옵저버를 추가해주고 해당 카드의 index 를 저장합니다.
2. 카드가 드랍 될 때 성공, 실패 여부를 담아 노티를 보냅니다.
3. 옵저버는 노티를 받아 cardDropped 메소드를 실행해줍니다.
4. cardDropped 메소드에서는 성공 실패 여부에 따라 카드를 지워줍니다.
5. 옵저버는 항상 드래그를 시작한 뷰 컨트롤러에만 존재해야하므로 cardDropped 메소드에서 옵저버를 지워줍니다.